### PR TITLE
Error reading artifact descriptor when a Java version based profile is required.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/src/main/java/maven/fetcher/MavenFetcher.java
+++ b/src/main/java/maven/fetcher/MavenFetcher.java
@@ -270,6 +270,7 @@ public class MavenFetcher {
         session
             .setLocalRepositoryManager(system().newLocalRepositoryManager(session, localRepository));
         session.setTransferListener(listener);
+        session.setSystemProperties(System.getProperties());
         proxy().ifPresent(session::setProxySelector);
         return session;
     }

--- a/src/main/java/maven/fetcher/internal/MavenArtifactFetcher.java
+++ b/src/main/java/maven/fetcher/internal/MavenArtifactFetcher.java
@@ -19,7 +19,6 @@ import org.eclipse.aether.graph.Exclusion;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.*;
 import org.eclipse.aether.transfer.ArtifactNotFoundException;
-import org.eclipse.aether.util.graph.selector.AndDependencySelector;
 import org.slf4j.Logger;
 
 import maven.fetcher.*;

--- a/src/test/java/maven/fetcher/test/TestMavenFetcher.java
+++ b/src/test/java/maven/fetcher/test/TestMavenFetcher.java
@@ -25,17 +25,17 @@ public class TestMavenFetcher {
         .toString();
 
     private Path localRepo;
-        
+
     @Before
     public void prepareLocalRepo() throws IOException {
         localRepo = Files.createTempDirectory("test");
     }
 
-    @After 
+    @After
     public void cleanLocalRepo() throws IOException {
         Files.walkFileTree(localRepo, new SimpleFileVisitor<>() {
             @Override
-            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) 
+            public FileVisitResult visitFile(Path path, BasicFileAttributes attrs)
             throws IOException {
                 Files.delete(path);
                 return FileVisitResult.CONTINUE;
@@ -43,7 +43,7 @@ public class TestMavenFetcher {
         });
     }
 
-    
+
     @Test
     public void fetchArtifactWithDependencies() {
         var result = new MavenFetcher()
@@ -95,6 +95,18 @@ public class TestMavenFetcher {
             .anyMatch(it -> it.groupId().equals("org.apache.maven") && it.artifactId().equals("maven-artifact"));
     }
 
+
+    @Test
+    public void fetchArtifactWithRequiredProfile() {
+        var result = new MavenFetcher()
+                .localRepositoryPath(localRepo.toString())
+                .logger(LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME))
+                .fetchArtifacts(
+                        new MavenFetchRequest("com.google.guava:guava:33.1.0-jre").scopes("compile")
+                );
+        System.out.println(result);
+        assertThat(result.allArtifacts()).size().isGreaterThan(1);
+    }
 
 
 


### PR DESCRIPTION
The system Java version was required to activate a profile and resolve dependencies.
Related issue: https://github.com/iti-ict/wakamiti/issues/239